### PR TITLE
feat: add Pearson footer definitions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@edx/frontend-component-footer",
-  "version": "1.0.0-semantically-released",
+  "name": "@pearsonedunext/frontend-component-footer",
+  "version": "12.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@edx/frontend-component-footer",
-      "version": "1.0.0-semantically-released",
+      "name": "@pearsonedunext/frontend-component-footer",
+      "version": "12.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@edx/frontend-component-footer",
-  "version": "1.0.0-semantically-released",
+  "name": "@pearsonedunext/frontend-component-footer",
+  "version": "12.0.0",
   "description": "Footer component for use when building Open edX frontend applications",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -11,11 +11,14 @@ import LanguageSelector from './LanguageSelector';
 ensureConfig([
   'LMS_BASE_URL',
   'LOGO_TRADEMARK_URL',
+  'FOOTER_PRIVACY_POLICY_LINK',
+  'FOOTER_TERMS_OF_SERVICE_LINK',
 ], 'Footer component');
 
 const EVENT_NAMES = {
   FOOTER_LINK: 'edx.bi.footer.link',
 };
+const dateNow = new Date();
 
 class SiteFooter extends React.Component {
   constructor(props) {
@@ -49,24 +52,29 @@ class SiteFooter extends React.Component {
         className="footer d-flex border-top py-3 px-4"
       >
         <div className="container-fluid d-flex">
-          <a
-            className="d-block"
-            href={config.LMS_BASE_URL}
-            aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
-          >
-            <img
-              style={{ maxHeight: 45 }}
-              src={logo || config.LOGO_TRADEMARK_URL}
-              alt={intl.formatMessage(messages['footer.logo.altText'])}
-            />
-          </a>
-          <div className="flex-grow-1" />
+          <ul>
+            <li>
+              <a href={config.FOOTER_PRIVACY_POLICY_LINK}>
+                {intl.formatMessage(messages['footer.legalLinks.privacyPolicy'])}
+              </a>
+            </li>
+            <li>
+              <a href={config.FOOTER_TERMS_OF_SERVICE_LINK}>
+                {intl.formatMessage(messages['footer.legalLinks.termsOfServiceNoHonorCode'])}
+              </a>
+            </li>
+          </ul>
           {showLanguageSelector && (
             <LanguageSelector
               options={supportedLanguages}
               onSubmit={onLanguageSelected}
             />
           )}
+        </div>
+        <div className="container-fluid d-flex copyright">
+          <p>
+            Copyright © {dateNow.getFullYear()} Pearson Education Inc. or its affiliate(s). All rights reserved.
+          </p>
         </div>
       </footer>
     );

--- a/src/components/Footer.messages.js
+++ b/src/components/Footer.messages.js
@@ -151,6 +151,11 @@ const messages = defineMessages({
     defaultMessage: 'Page Footer',
     description: 'aria-label for the footer component',
   },
+  'footer.legalLinks.termsOfServiceNoHonorCode': {
+    id: 'footer.legalLinks.termsOfServiceNoHonorCode',
+    defaultMessage: 'Terms of Service',
+    description: 'The label for the link to the edX terms of service page.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Description:

This PR adds Pearson definitions to the footer component.

## Screenshot:
![image](https://github.com/Pearson-Advance/frontend-component-footer/assets/17520199/a5d5ec26-cd85-44f4-9db3-f97449acc535)

## How to test:

- Clone this repository.
- Clone any MFE, i.e. https://github.com/openedx/frontend-app-learning/
- Add this module definition to the Learning MFE: https://github.com/openedx/frontend-build#local-module-configuration-for-webpack
- Run this in the component footer folder: npm install & npm run build
- Install the footer as follows: npm install @edx/frontend-component-footer@file:../path-to-the-local-footer-component
- Install the Pearson brand package: npm install @edx/brand@git+ssh://git@github.com:Pearson-Advance/brand-pearson.com.git#v0.2.2
- Run npm install & npm run start

## Notes:

- These changes require the Pearson brand package.
- This package must be published to the NPM registry: https://www.npmjs.com/package/@pearsonedunext/frontend-component-footer and for now, this process is handled manually and then must be installed as follows:  npm install @edx/frontend-component-footer@npm:@pearsonedunext/frontend-component-footer@12.0.0

## Reviewers:

- [ ] @anfbermudezme 
- [ ] @alexjmpb 
