### PR TITLE
feat[ulmo]: Add pearson definitions in footer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,3 @@ jobs:
       run: npm run build
     - name: i18n_extract
       run: npm run i18n_extract
-    - name: Coverage
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,6 @@ jobs:
       run: npm run test
     - name: i18n_extract
       run: npm run i18n_extract
-    - name: Coverage
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: false
     - name: Build
       run: npm run build
     - name: Release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edx/frontend-component-footer",
-  "version": "1.0.0-semantically-released",
+  "version": "13.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edx/frontend-component-footer",
-      "version": "1.0.0-semantically-released",
+      "version": "13.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@edx/frontend-component-footer",
-  "version": "1.0.0-semantically-released",
+  "name": "@pearsonedunext/frontend-component-footer",
+  "version": "12.0.0",
   "description": "Footer component for use when building Open edX frontend applications",
   "main": "dist/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pearsonedunext/frontend-component-footer",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Footer component for use when building Open edX frontend applications",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { ensureConfig } from '@edx/frontend-platform';
 import { AppContext } from '@edx/frontend-platform/react';
 
@@ -24,22 +23,11 @@ const dateNow = new Date();
 const SiteFooter = ({
   supportedLanguages,
   onLanguageSelected,
-  logo,
 }) => {
   const intl = useIntl();
   const { config } = useContext(AppContext);
 
   const showLanguageSelector = supportedLanguages.length > 0 && onLanguageSelected;
-
-  const externalLinkClickHandler = (event) => {
-    const label = event.currentTarget.getAttribute('href');
-    const eventName = EVENT_NAMES.FOOTER_LINK;
-    const properties = {
-      category: 'outbound_link',
-      label,
-    };
-    sendTrackEvent(eventName, properties);
-  };
 
   return (
     <footer
@@ -49,12 +37,12 @@ const SiteFooter = ({
       <div className="container-fluid d-flex">
         <ul>
           <li>
-            <a href={config.FOOTER_PRIVACY_POLICY_LINK}>
+            <a href={config.FOOTER_PRIVACY_POLICY_LINK} target="_blank" rel="noopener noreferrer">
               {intl.formatMessage(messages['footer.legalLinks.privacyPolicy'])}
             </a>
           </li>
           <li>
-            <a href={config.FOOTER_TERMS_OF_SERVICE_LINK}>
+            <a href={config.FOOTER_TERMS_OF_SERVICE_LINK} target="_blank" rel="noopener noreferrer">
               {intl.formatMessage(messages['footer.legalLinks.termsOfServiceNoHonorCode'])}
             </a>
           </li>
@@ -77,7 +65,6 @@ const SiteFooter = ({
 };
 
 SiteFooter.propTypes = {
-  logo: PropTypes.string,
   onLanguageSelected: PropTypes.func,
   supportedLanguages: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string.isRequired,
@@ -86,7 +73,6 @@ SiteFooter.propTypes = {
 };
 
 SiteFooter.defaultProps = {
-  logo: undefined,
   onLanguageSelected: undefined,
   supportedLanguages: [],
 };

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -11,11 +11,15 @@ import LanguageSelector from './LanguageSelector';
 ensureConfig([
   'LMS_BASE_URL',
   'LOGO_TRADEMARK_URL',
+  'FOOTER_PRIVACY_POLICY_LINK',
+  'FOOTER_TERMS_OF_SERVICE_LINK',
 ], 'Footer component');
 
 const EVENT_NAMES = {
   FOOTER_LINK: 'edx.bi.footer.link',
 };
+
+const dateNow = new Date();
 
 const SiteFooter = ({
   supportedLanguages,
@@ -43,18 +47,18 @@ const SiteFooter = ({
       className="footer d-flex border-top py-3 px-4"
     >
       <div className="container-fluid d-flex">
-        <a
-          className="d-block"
-          href={config.LMS_BASE_URL}
-          aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
-          onClick={externalLinkClickHandler}
-        >
-          <img
-            style={{ maxHeight: 45 }}
-            src={logo || config.LOGO_TRADEMARK_URL}
-            alt={intl.formatMessage(messages['footer.logo.altText'])}
-          />
-        </a>
+        <ul>
+          <li>
+            <a href={config.FOOTER_PRIVACY_POLICY_LINK}>
+              {intl.formatMessage(messages['footer.legalLinks.privacyPolicy'])}
+            </a>
+          </li>
+          <li>
+            <a href={config.FOOTER_TERMS_OF_SERVICE_LINK}>
+              {intl.formatMessage(messages['footer.legalLinks.termsOfServiceNoHonorCode'])}
+            </a>
+          </li>
+        </ul>
         <div className="flex-grow-1" />
         {showLanguageSelector && (
           <LanguageSelector
@@ -62,6 +66,11 @@ const SiteFooter = ({
             onSubmit={onLanguageSelected}
           />
         )}
+      </div>
+      <div className="container-fluid d-flex copyright">
+        <p>
+          Copyright © {dateNow.getFullYear()} Pearson Education Inc. or its affiliate(s). All rights reserved.
+        </p>
       </div>
     </footer>
   );

--- a/src/components/Footer.messages.js
+++ b/src/components/Footer.messages.js
@@ -151,6 +151,11 @@ const messages = defineMessages({
     defaultMessage: 'Page Footer',
     description: 'aria-label for the footer component',
   },
+  'footer.legalLinks.termsOfServiceNoHonorCode': {
+    id: 'footer.legalLinks.termsOfServiceNoHonorCode',
+    defaultMessage: 'Terms of Service',
+    description: 'The label for the link to the edX terms of service page.',
+  },
 });
 
 export default messages;

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -8,22 +8,24 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
   <div
     className="container-fluid d-flex"
   >
-    <a
-      aria-label="edX Home"
-      className="d-block"
-      href="http://localhost:18000"
-      onClick={[Function]}
-    >
-      <img
-        alt="Powered by Open edX"
-        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-        style={
-          {
-            "maxHeight": 45,
-          }
-        }
-      />
-    </a>
+    <ul>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Privacy Policy
+        </a>
+      </li>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Terms of Service
+        </a>
+      </li>
+    </ul>
     <div
       className="flex-grow-1"
     />
@@ -67,6 +69,15 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
       </div>
     </form>
   </div>
+  <div
+    className="container-fluid d-flex copyright"
+  >
+    <p>
+      Copyright © 
+      2025
+       Pearson Education Inc. or its affiliate(s). All rights reserved.
+    </p>
+  </div>
 </footer>
 `;
 
@@ -78,25 +89,36 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
   <div
     className="container-fluid d-flex"
   >
-    <a
-      aria-label="edX Home"
-      className="d-block"
-      href="http://localhost:18000"
-      onClick={[Function]}
-    >
-      <img
-        alt="Powered by Open edX"
-        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-        style={
-          {
-            "maxHeight": 45,
-          }
-        }
-      />
-    </a>
+    <ul>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Privacy Policy
+        </a>
+      </li>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Terms of Service
+        </a>
+      </li>
+    </ul>
     <div
       className="flex-grow-1"
     />
+  </div>
+  <div
+    className="container-fluid d-flex copyright"
+  >
+    <p>
+      Copyright © 
+      2025
+       Pearson Education Inc. or its affiliate(s). All rights reserved.
+    </p>
   </div>
 </footer>
 `;
@@ -109,25 +131,36 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
   <div
     className="container-fluid d-flex"
   >
-    <a
-      aria-label="edX Home"
-      className="d-block"
-      href="http://localhost:18000"
-      onClick={[Function]}
-    >
-      <img
-        alt="Powered by Open edX"
-        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-        style={
-          {
-            "maxHeight": 45,
-          }
-        }
-      />
-    </a>
+    <ul>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Privacy Policy
+        </a>
+      </li>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Terms of Service
+        </a>
+      </li>
+    </ul>
     <div
       className="flex-grow-1"
     />
+  </div>
+  <div
+    className="container-fluid d-flex copyright"
+  >
+    <p>
+      Copyright © 
+      2025
+       Pearson Education Inc. or its affiliate(s). All rights reserved.
+    </p>
   </div>
 </footer>
 `;


### PR DESCRIPTION
### Ticket
https://pearson.atlassian.net/browse/PADV-2810

### Description
This PR removes the logo in the footer and adds the privacy and terms links and copyright text

### Changes Made
Add FOOTER_PRIVACY_POLICY_LINK and FOOTER_TERMS_OF_SERVICE_LINK variables
Add copyright text

### Screenshot
📸 Before 
<img width="1256" height="78" alt="image" src="https://github.com/user-attachments/assets/b885a0b1-c5d2-4624-ba19-95949959f9f1" />


📸 After 
<img width="1263" height="107" alt="image" src="https://github.com/user-attachments/assets/6788cb43-893b-4715-86a5-262938707eb1" />

NOTE: pearson branding is not working correctly locally, but that is part of other scope 

### How to Test
npm install
npm run start 
go to http://localhost:8080/
