### PR TITLE
feat: add configs in footer

### DIFF
--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -10,10 +10,11 @@
     ul {
       list-style: none;
       display: inline-flex;
+      flex-wrap: wrap;
       padding: 0;
       margin-bottom: 3rem;
 
-      li:last-child::before {
+      li:not(:first-child)::before {
         content: "|";
         padding: 0 20px;
         color: var(--pgn-color-white);

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { ensureConfig } from '@edx/frontend-platform';
+import { ensureConfig, getConfig } from '@edx/frontend-platform';
 import { AppContext } from '@edx/frontend-platform/react';
 
 import messages from './Footer.messages';
@@ -27,6 +27,9 @@ const SiteFooter = ({
   const intl = useIntl();
   const { config } = useContext(AppContext);
 
+  const extraLinks = getConfig().FOOTER_EXTRA_LINKS || [];
+  const showFooterCopyright = getConfig().SHOW_FOOTER_COPYRIGHT !== false;
+
   const showLanguageSelector = supportedLanguages.length > 0 && onLanguageSelected;
 
   return (
@@ -46,6 +49,21 @@ const SiteFooter = ({
               {intl.formatMessage(messages['footer.legalLinks.termsOfServiceNoHonorCode'])}
             </a>
           </li>
+
+          {Array.isArray(extraLinks) && extraLinks.map((item) => {
+            if (!item?.text || !item?.link) {
+              return null;
+            }
+
+            return (
+              <li key={item.link}>
+                <a href={item.link} target="_blank" rel="noopener noreferrer">
+                  {item.text}
+                </a>
+              </li>
+            );
+          })}
+
         </ul>
         <div className="flex-grow-1" />
         {showLanguageSelector && (
@@ -55,11 +73,13 @@ const SiteFooter = ({
           />
         )}
       </div>
-      <div className="container-fluid d-flex copyright">
-        <p>
-          Copyright © {dateNow.getFullYear()} Pearson Education Inc. or its affiliate(s). All rights reserved.
-        </p>
-      </div>
+      {showFooterCopyright && (
+        <div className="container-fluid d-flex copyright mt-2">
+          <p className="mb-0">
+            Copyright © {dateNow.getFullYear()} Pearson Education Inc. or its affiliate(s). All rights reserved.
+          </p>
+        </div>
+      )}
     </footer>
   );
 };

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -5,10 +5,19 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
+import { getConfig } from '@edx/frontend-platform';
 
 import Footer from './Footer';
 import FooterSlot from '../plugin-slots/FooterSlot';
 import StudioFooterHelpSectionSlot from '../plugin-slots/StudioFooterHelpSectionSlot';
+
+jest.mock('@edx/frontend-platform', () => {
+  const originalModule = jest.requireActual('@edx/frontend-platform');
+  return {
+    ...originalModule,
+    getConfig: jest.fn(() => ({})),
+  };
+});
 
 const FooterWithContext = ({ locale = 'es' }) => {
   const contextValue = useMemo(() => ({
@@ -57,6 +66,11 @@ const FooterWithLanguageSelector = ({ languageSelected = () => {} }) => {
 };
 
 describe('<Footer />', () => {
+  beforeEach(() => {
+    getConfig.mockReset();
+    getConfig.mockReturnValue({});
+  });
+
   describe('renders correctly', () => {
     it('renders without a language selector', () => {
       const tree = renderer
@@ -73,6 +87,30 @@ describe('<Footer />', () => {
     it('renders with a language selector', () => {
       const tree = renderer
         .create(<FooterWithLanguageSelector />)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    it('renders dynamic extra links from getConfig', () => {
+      getConfig.mockReturnValue({
+        FOOTER_EXTRA_LINKS: [
+          { text: 'Custom Link 1', link: 'https://custom1.com' },
+          { text: 'Custom Link 2', link: 'https://custom2.com' },
+        ],
+      });
+
+      const tree = renderer
+        .create(<FooterWithContext locale="en" />)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('hides copyright when SHOW_FOOTER_COPYRIGHT is false', () => {
+      getConfig.mockReturnValue({
+        SHOW_FOOTER_COPYRIGHT: false,
+      });
+
+      const tree = renderer
+        .create(<FooterWithContext locale="en" />)
         .toJSON();
       expect(tree).toMatchSnapshot();
     });

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -1,5 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Footer /> renders correctly hides copyright when SHOW_FOOTER_COPYRIGHT is false 1`] = `
+<footer
+  className="footer d-flex border-top py-3 px-4"
+  role="contentinfo"
+>
+  <div
+    className="container-fluid d-flex"
+  >
+    <ul>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Privacy Policy
+        </a>
+      </li>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Terms of Service
+        </a>
+      </li>
+    </ul>
+    <div
+      className="flex-grow-1"
+    />
+  </div>
+</footer>
+`;
+
+exports[`<Footer /> renders correctly renders dynamic extra links from getConfig 1`] = `
+<footer
+  className="footer d-flex border-top py-3 px-4"
+  role="contentinfo"
+>
+  <div
+    className="container-fluid d-flex"
+  >
+    <ul>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Privacy Policy
+        </a>
+      </li>
+      <li>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Terms of Service
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://custom1.com"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Custom Link 1
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://custom2.com"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Custom Link 2
+        </a>
+      </li>
+    </ul>
+    <div
+      className="flex-grow-1"
+    />
+  </div>
+  <div
+    className="container-fluid d-flex copyright mt-2"
+  >
+    <p
+      className="mb-0"
+    >
+      Copyright © 
+      2026
+       Pearson Education Inc. or its affiliate(s). All rights reserved.
+    </p>
+  </div>
+</footer>
+`;
+
 exports[`<Footer /> renders correctly renders with a language selector 1`] = `
 <footer
   className="footer d-flex border-top py-3 px-4"
@@ -70,9 +165,11 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
     </form>
   </div>
   <div
-    className="container-fluid d-flex copyright"
+    className="container-fluid d-flex copyright mt-2"
   >
-    <p>
+    <p
+      className="mb-0"
+    >
       Copyright © 
       2026
        Pearson Education Inc. or its affiliate(s). All rights reserved.
@@ -112,9 +209,11 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
     />
   </div>
   <div
-    className="container-fluid d-flex copyright"
+    className="container-fluid d-flex copyright mt-2"
   >
-    <p>
+    <p
+      className="mb-0"
+    >
       Copyright © 
       2026
        Pearson Education Inc. or its affiliate(s). All rights reserved.
@@ -154,9 +253,11 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
     />
   </div>
   <div
-    className="container-fluid d-flex copyright"
+    className="container-fluid d-flex copyright mt-2"
   >
-    <p>
+    <p
+      className="mb-0"
+    >
       Copyright © 
       2026
        Pearson Education Inc. or its affiliate(s). All rights reserved.


### PR DESCRIPTION
## Ticket
https://pearson.atlassian.net/browse/PADV-3449

## Description
This PR enhances the `SiteFooter` component to make it more dynamic and configurable per site. It introduces the ability to render custom additional links provided by the site configuration and adds a feature toggle to show or hide the copyright section depending on organizational needs, fallbacking to the default behavior if no custom configuration is provided.

## Changes Made
* **Dynamic Links Support**: Integrated `getConfig()` from `@edx/frontend-platform` to fetch `FOOTER_EXTRA_LINKS`. The component now safely maps over this array of objects to render any custom links dynamically.
* **Copyright Toggle**: Added support for `SHOW_FOOTER_COPYRIGHT` via `getConfig()`. The copyright section now defaults to `true` (visible) and can be explicitly hidden if configured as `false`.
* **Style Optimizations**: Updated the footer's SCSS layout (`flex-column`) and adjusted the list separator styling (`li:not(:first-child)::before`) to natively support more than two links without layout breakage or hover style specificity issues.
* **Unit Tests**: Added new test cases in `Footer.test.jsx` to spy on `getConfig()` and guarantee correct snapshot rendering for both extra links and hidden copyright scenarios.

## How to Test
1. **Setup local configurations:** Since `getConfig()` relies on platform injection, you can temporarily mock or add these values to your application environment/MFE setup.

2. **Verify Extra Links:**
   Configure `FOOTER_EXTRA_LINKS` with an array of objects like:
   ```json
   [
     {"text": "Help Center", "link": "[https://example.com/help](https://example.com/help)"},
     {"text": "Contact Us", "link": "[https://example.com/contact](https://example.com/contact)"}
   ]