### PR TITLE
feat: add variable to footer copy

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -18,7 +18,7 @@ const EVENT_NAMES = {
   FOOTER_LINK: 'edx.bi.footer.link',
 };
 
-const dateNow = new Date();
+const DEFAULT_COPYRIGHT_TEXT = 'Copyright © {year} Pearson Education Inc. or its affiliate(s). All rights reserved.';
 
 const SiteFooter = ({
   supportedLanguages,
@@ -29,6 +29,11 @@ const SiteFooter = ({
 
   const extraLinks = getConfig().FOOTER_EXTRA_LINKS || [];
   const showFooterCopyright = getConfig().SHOW_FOOTER_COPYRIGHT !== false;
+
+  const rawCopyrightText = getConfig().FOOTER_COPYRIGHT_TEXT || DEFAULT_COPYRIGHT_TEXT;
+
+  const currentYear = new Date().getFullYear();
+  const copyrightText = rawCopyrightText.replace('{year}', currentYear);
 
   const showLanguageSelector = supportedLanguages.length > 0 && onLanguageSelected;
 
@@ -75,9 +80,7 @@ const SiteFooter = ({
       </div>
       {showFooterCopyright && (
         <div className="container-fluid d-flex copyright mt-2">
-          <p className="mb-0">
-            Copyright © {dateNow.getFullYear()} Pearson Education Inc. or its affiliate(s). All rights reserved.
-          </p>
+          <p className="mb-0">{copyrightText}</p>
         </div>
       )}
     </footer>

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform';
+import '@testing-library/jest-dom';
 
 import Footer from './Footer';
 import FooterSlot from '../plugin-slots/FooterSlot';
@@ -113,6 +114,28 @@ describe('<Footer />', () => {
         .create(<FooterWithContext locale="en" />)
         .toJSON();
       expect(tree).toMatchSnapshot();
+    });
+
+    it('renders default copyright text with current year', () => {
+      render(<FooterWithContext locale="en" />);
+
+      const currentYear = new Date().getFullYear();
+      const expectedText = `Copyright © ${currentYear} Pearson Education Inc. or its affiliate(s). All rights reserved.`;
+
+      expect(screen.getByText(expectedText)).toBeInTheDocument();
+    });
+
+    it('renders custom copyright text from getConfig replacing {year}', () => {
+      const currentYear = new Date().getFullYear();
+      getConfig.mockReturnValue({
+        FOOTER_COPYRIGHT_TEXT: 'Copyright © {year} My Custom Company. All rights reserved.',
+      });
+
+      render(<FooterWithContext locale="en" />);
+
+      expect(
+        screen.getByText(`Copyright © ${currentYear} My Custom Company. All rights reserved.`),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -87,9 +87,7 @@ exports[`<Footer /> renders correctly renders dynamic extra links from getConfig
     <p
       className="mb-0"
     >
-      Copyright © 
-      2026
-       Pearson Education Inc. or its affiliate(s). All rights reserved.
+      Copyright © 2026 Pearson Education Inc. or its affiliate(s). All rights reserved.
     </p>
   </div>
 </footer>
@@ -170,9 +168,7 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
     <p
       className="mb-0"
     >
-      Copyright © 
-      2026
-       Pearson Education Inc. or its affiliate(s). All rights reserved.
+      Copyright © 2026 Pearson Education Inc. or its affiliate(s). All rights reserved.
     </p>
   </div>
 </footer>
@@ -214,9 +210,7 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
     <p
       className="mb-0"
     >
-      Copyright © 
-      2026
-       Pearson Education Inc. or its affiliate(s). All rights reserved.
+      Copyright © 2026 Pearson Education Inc. or its affiliate(s). All rights reserved.
     </p>
   </div>
 </footer>
@@ -258,9 +252,7 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
     <p
       className="mb-0"
     >
-      Copyright © 
-      2026
-       Pearson Education Inc. or its affiliate(s). All rights reserved.
+      Copyright © 2026 Pearson Education Inc. or its affiliate(s). All rights reserved.
     </p>
   </div>
 </footer>


### PR DESCRIPTION
##Ticket
https://pearson.atlassian.net/browse/PADV-3550

## Description
This PR makes the footer copyright text configurable dynamically via site settings while supporting auto-filled current year interpolation (e.g., replacing `{year}`). If no custom text is provided, it falls back gracefully to the default copyright notice.

## Changes Made
- Added support for reading `FOOTER_COPYRIGHT_TEXT` from site configuration (`getConfig()`).
- Implemented dynamic `{year}` placeholder replacement with the current calendar year.
- Preserved the existing copyright string as the default fallback value.
- Updated unit tests (`Footer.test.jsx`) to cover both default copyright rendering and custom template replacement.

## Screenshoot
-Default
<img width="1229" height="133" alt="image" src="https://github.com/user-attachments/assets/c48fa7c4-99d8-44b9-b1b4-40008badbcd8" />

-Custom copy
<img width="1230" height="133" alt="image" src="https://github.com/user-attachments/assets/d2f1333a-ccf7-462f-9429-5daa9f7dbd73" />

## How to Test
1. **Setup local configurations:** Since `getConfig()` relies on platform injection, you can temporarily mock or add these values to your application environment/MFE setup.

2. **Verify Extra Links:**
   Configure `FOOTER_COPYRIGHT_TEXT` with this value:
```env
     FOOTER_COPYRIGHT_TEXT="Copyright © {year} My Custom Org."