### PR TITLE
feat: change approach to copy from config

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -18,8 +18,6 @@ const EVENT_NAMES = {
   FOOTER_LINK: 'edx.bi.footer.link',
 };
 
-const DEFAULT_COPYRIGHT_TEXT = 'Copyright © {year} Pearson Education Inc. or its affiliate(s). All rights reserved.';
-
 const SiteFooter = ({
   supportedLanguages,
   onLanguageSelected,
@@ -29,11 +27,9 @@ const SiteFooter = ({
 
   const extraLinks = getConfig().FOOTER_EXTRA_LINKS || [];
   const showFooterCopyright = getConfig().SHOW_FOOTER_COPYRIGHT !== false;
-
-  const rawCopyrightText = getConfig().FOOTER_COPYRIGHT_TEXT || DEFAULT_COPYRIGHT_TEXT;
+  const customCopyrightText = getConfig().FOOTER_COPYRIGHT_TEXT;
 
   const currentYear = new Date().getFullYear();
-  const copyrightText = rawCopyrightText.replace('{year}', currentYear);
 
   const showLanguageSelector = supportedLanguages.length > 0 && onLanguageSelected;
 
@@ -80,7 +76,11 @@ const SiteFooter = ({
       </div>
       {showFooterCopyright && (
         <div className="container-fluid d-flex copyright mt-2">
-          <p className="mb-0">{copyrightText}</p>
+          <p className="mb-0">
+            {customCopyrightText || (
+              `Copyright © ${currentYear} Pearson Education Inc. or its affiliate(s). All rights reserved.`
+            )}
+          </p>
         </div>
       )}
     </footer>

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -125,17 +125,15 @@ describe('<Footer />', () => {
       expect(screen.getByText(expectedText)).toBeInTheDocument();
     });
 
-    it('renders custom copyright text from getConfig replacing {year}', () => {
-      const currentYear = new Date().getFullYear();
+    it('renders custom copyright text from getConfig', () => {
+      const customText = 'Copyright © 2026 My Custom Company';
       getConfig.mockReturnValue({
-        FOOTER_COPYRIGHT_TEXT: 'Copyright © {year} My Custom Company. All rights reserved.',
+        FOOTER_COPYRIGHT_TEXT: customText,
       });
 
       render(<FooterWithContext locale="en" />);
 
-      expect(
-        screen.getByText(`Copyright © ${currentYear} My Custom Company. All rights reserved.`),
-      ).toBeInTheDocument();
+      expect(screen.getByText(customText)).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Ticket
https://pearson.atlassian.net/browse/PADV-3550

## Description
Updated the site footer copyright logic to read `FOOTER_COPYRIGHT_TEXT` dynamically. There is an issue in stage, probably for the runtime and build time variables that set the value for rawCopyrightText always the default value so the custom value from site configuration is not read.

Instead of manipulating strings with runtime placeholder replacements (like `.replace('{year}')`), the component now renders the custom copyright text directly when provided by the site configuration. If no custom string is found, it falls back to rendering the default copyright notice with the current year interpolated natively in JSX.

## Changes Made
- Simplified the rendering logic: renders `customCopyrightText` as-is when available, otherwise renders the default Pearson copyright notice with `new Date().getFullYear()`.
- Updated unit tests (`Footer.test.jsx`) 

## How to Test
1. **Setup local configurations:** Since `getConfig()` relies on platform injection, you can temporarily mock or add these values to your application environment/MFE setup.

2. **Verify Extra Links:**
   Configure `FOOTER_COPYRIGHT_TEXT` with this value:
```env
     FOOTER_COPYRIGHT_TEXT="Copyright © {year} My Custom Org."